### PR TITLE
feat: adiciona endpoint de versão ao PS_User

### DIFF
--- a/src/main/java/com/mypetadmin/ps_user/controller/VersionController.java
+++ b/src/main/java/com/mypetadmin/ps_user/controller/VersionController.java
@@ -1,0 +1,20 @@
+package com.mypetadmin.ps_user.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class VersionController {
+
+    private final String commit;
+
+    public VersionController(@Value("${app.git-commit:${RENDER_GIT_COMMIT:unknown}}") String commit) {
+        this.commit = commit;
+    }
+
+    @GetMapping("/version")
+    public String version() {
+        return commit;
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/security/SecurityConfig.java
+++ b/src/main/java/com/mypetadmin/ps_user/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .formLogin(form -> form.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/version").permitAll()
                         .requestMatchers("/internal/**", "/actuator/prometheus", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").hasRole("INTERNAL")
                         .anyRequest().denyAll()
                 )

--- a/src/test/java/com/mypetadmin/ps_user/controller/VersionControllerTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/controller/VersionControllerTest.java
@@ -1,0 +1,15 @@
+package com.mypetadmin.ps_user.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionControllerTest {
+
+    @Test
+    void deveRetornarCommitConfigurado() {
+        VersionController controller = new VersionController("abc123");
+
+        assertThat(controller.version()).isEqualTo("abc123");
+    }
+}


### PR DESCRIPTION
## Objetivo
Preparar o `PS_User` para verificação de deploy por commit, seguindo o padrão já usado em `PS_Empresa` e `PS_Contrato`.

## Alterações
- adiciona `GET /version`;
- expõe `/version` sem autenticação;
- resolve o commit a partir de `RENDER_GIT_COMMIT`, com fallback `unknown`;
- adiciona teste unitário do controller.

## Observação
Este PR não cria release pipeline nem depende de Render/Neon. Ele apenas deixa o serviço pronto para que o primeiro deploy live possa ser verificado pelo SHA exato.