### PR TITLE
feat: aplica hierarquia de criação e exclusão no PS_User

### DIFF
--- a/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
+++ b/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
@@ -1,5 +1,6 @@
 package com.mypetadmin.ps_user.controller;
 
+import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.service.UsuarioService;
@@ -7,20 +8,42 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/internal/usuarios")
 @RequiredArgsConstructor
 public class InternalUsuarioController {
 
+    private static final String ACTOR_USER_ID_HEADER = "X-Actor-User-Id";
+
     private final UsuarioService usuarioService;
 
     @PostMapping("/master")
     public ResponseEntity<UsuarioResponseDTO> criarMaster(@Valid @RequestBody UsuarioMasterCreateRequestDTO request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(usuarioService.criarMaster(request));
+    }
+
+    @PostMapping
+    public ResponseEntity<UsuarioResponseDTO> criarUsuario(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @Valid @RequestBody UsuarioCreateRequestDTO request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(usuarioService.criarUsuario(actorUserId, request));
+    }
+
+    @DeleteMapping("/{usuarioId}")
+    public ResponseEntity<Void> excluirUsuario(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @PathVariable UUID usuarioId) {
+        usuarioService.excluirUsuario(actorUserId, usuarioId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioCreateRequestDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioCreateRequestDTO.java
@@ -1,0 +1,14 @@
+package com.mypetadmin.ps_user.dto;
+
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UsuarioCreateRequestDTO(
+        @NotBlank @Size(max = 150) String nome,
+        @NotBlank @Email @Size(max = 320) String email,
+        @NotNull RoleUsuario role
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioResponseDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioResponseDTO.java
@@ -13,6 +13,7 @@ public record UsuarioResponseDTO(
         String nome,
         String email,
         StatusUsuario status,
+        boolean primaryMaster,
         Set<RoleUsuario> roles,
         OffsetDateTime dataCriacao,
         OffsetDateTime dataAtualizacao

--- a/src/main/java/com/mypetadmin/ps_user/entity/Usuario.java
+++ b/src/main/java/com/mypetadmin/ps_user/entity/Usuario.java
@@ -54,6 +54,9 @@ public class Usuario {
     @Column(nullable = false, length = 20)
     private StatusUsuario status;
 
+    @Column(name = "primary_master", nullable = false)
+    private boolean primaryMaster;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "usuario_roles", joinColumns = @JoinColumn(name = "usuario_id"))
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mypetadmin/ps_user/enums/RoleUsuario.java
+++ b/src/main/java/com/mypetadmin/ps_user/enums/RoleUsuario.java
@@ -3,5 +3,9 @@ package com.mypetadmin.ps_user.enums;
 public enum RoleUsuario {
     MASTER,
     ADMIN,
-    USER
+    LOJA,
+    VETERINARIO,
+    BANHO,
+    HOTEL,
+    CRECHE
 }

--- a/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package com.mypetadmin.ps_user.exception;
 
-import jakarta.servlet.ServletRequestBindingException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;

--- a/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.mypetadmin.ps_user.exception;
 
+import jakarta.servlet.ServletRequestBindingException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -62,6 +65,13 @@ public class GlobalExceptionHandler {
                 request.getRequestURI(),
                 ex.getBindingResult().getFieldErrors().stream().map(error -> error.getField()).distinct().toList());
         return response(HttpStatus.BAD_REQUEST, "USER_VALIDATION_ERROR", "Dados inválidos", request);
+    }
+
+    @ExceptionHandler({ServletRequestBindingException.class, MethodArgumentTypeMismatchException.class, HttpMessageNotReadableException.class})
+    ResponseEntity<ErrorResponse> handleBadRequest(Exception ex, HttpServletRequest request) {
+        log.warn("request.bad_request method={} path={} type={}",
+                request.getMethod(), request.getRequestURI(), ex.getClass().getSimpleName());
+        return response(HttpStatus.BAD_REQUEST, "USER_BAD_REQUEST", "Requisição inválida", request);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
@@ -25,6 +25,26 @@ public class GlobalExceptionHandler {
         return build(HttpStatus.CONFLICT, "USER_ONBOARDING_CONFLICT", ex, request);
     }
 
+    @ExceptionHandler(PrimaryMasterExistenteException.class)
+    ResponseEntity<ErrorResponse> handlePrimaryMasterExists(PrimaryMasterExistenteException ex, HttpServletRequest request) {
+        return build(HttpStatus.CONFLICT, "USER_PRIMARY_MASTER_EXISTS", ex, request);
+    }
+
+    @ExceptionHandler(PrimeiroMasterProtegidoException.class)
+    ResponseEntity<ErrorResponse> handlePrimaryMasterProtected(PrimeiroMasterProtegidoException ex, HttpServletRequest request) {
+        return build(HttpStatus.CONFLICT, "USER_PRIMARY_MASTER_PROTECTED", ex, request);
+    }
+
+    @ExceptionHandler(UsuarioNaoEncontradoException.class)
+    ResponseEntity<ErrorResponse> handleUserNotFound(UsuarioNaoEncontradoException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", ex, request);
+    }
+
+    @ExceptionHandler(UsuarioOperacaoNaoPermitidaException.class)
+    ResponseEntity<ErrorResponse> handleUserForbidden(UsuarioOperacaoNaoPermitidaException ex, HttpServletRequest request) {
+        return build(HttpStatus.FORBIDDEN, "USER_OPERATION_FORBIDDEN", ex, request);
+    }
+
     @ExceptionHandler(EmpresaNaoEncontradaException.class)
     ResponseEntity<ErrorResponse> handleEmpresaNotFound(EmpresaNaoEncontradaException ex, HttpServletRequest request) {
         return build(HttpStatus.UNPROCESSABLE_ENTITY, "USER_EMPRESA_NOT_FOUND", ex, request);

--- a/src/main/java/com/mypetadmin/ps_user/exception/PrimaryMasterExistenteException.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/PrimaryMasterExistenteException.java
@@ -1,0 +1,7 @@
+package com.mypetadmin.ps_user.exception;
+
+public class PrimaryMasterExistenteException extends RuntimeException {
+    public PrimaryMasterExistenteException() {
+        super("A empresa já possui o primeiro MASTER cadastrado");
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/exception/PrimeiroMasterProtegidoException.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/PrimeiroMasterProtegidoException.java
@@ -1,0 +1,7 @@
+package com.mypetadmin.ps_user.exception;
+
+public class PrimeiroMasterProtegidoException extends RuntimeException {
+    public PrimeiroMasterProtegidoException() {
+        super("O primeiro MASTER da empresa não pode ser excluído");
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/exception/UsuarioNaoEncontradoException.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/UsuarioNaoEncontradoException.java
@@ -1,0 +1,7 @@
+package com.mypetadmin.ps_user.exception;
+
+public class UsuarioNaoEncontradoException extends RuntimeException {
+    public UsuarioNaoEncontradoException() {
+        super("Usuário não encontrado");
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/exception/UsuarioOperacaoNaoPermitidaException.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/UsuarioOperacaoNaoPermitidaException.java
@@ -1,0 +1,7 @@
+package com.mypetadmin.ps_user.exception;
+
+public class UsuarioOperacaoNaoPermitidaException extends RuntimeException {
+    public UsuarioOperacaoNaoPermitidaException() {
+        super("Usuário não possui permissão para esta operação");
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/mapper/UsuarioMapper.java
+++ b/src/main/java/com/mypetadmin/ps_user/mapper/UsuarioMapper.java
@@ -16,6 +16,7 @@ public class UsuarioMapper {
                 usuario.getNome(),
                 usuario.getEmail(),
                 usuario.getStatus(),
+                usuario.isPrimaryMaster(),
                 Set.copyOf(usuario.getRoles()),
                 usuario.getDataCriacao(),
                 usuario.getDataAtualizacao()

--- a/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
+++ b/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
@@ -10,5 +10,9 @@ public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
 
     Optional<Usuario> findByOnboardingId(UUID onboardingId);
 
+    Optional<Usuario> findByIdAndEmpresaId(UUID id, UUID empresaId);
+
     boolean existsByEmailIgnoreCase(String email);
+
+    boolean existsByEmpresaIdAndPrimaryMasterTrue(UUID empresaId);
 }

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
@@ -1,8 +1,15 @@
 package com.mypetadmin.ps_user.service;
 
+import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 
+import java.util.UUID;
+
 public interface UsuarioService {
     UsuarioResponseDTO criarMaster(UsuarioMasterCreateRequestDTO request);
+
+    UsuarioResponseDTO criarUsuario(UUID actorUserId, UsuarioCreateRequestDTO request);
+
+    void excluirUsuario(UUID actorUserId, UUID usuarioId);
 }

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
@@ -2,6 +2,7 @@ package com.mypetadmin.ps_user.service;
 
 import com.mypetadmin.ps_user.client.EmpresaClient;
 import com.mypetadmin.ps_user.dto.EmpresaStatusResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.entity.Usuario;
@@ -11,6 +12,10 @@ import com.mypetadmin.ps_user.exception.EmailExistenteException;
 import com.mypetadmin.ps_user.exception.EmpresaIndisponivelException;
 import com.mypetadmin.ps_user.exception.EmpresaNaoEncontradaException;
 import com.mypetadmin.ps_user.exception.OnboardingConflictException;
+import com.mypetadmin.ps_user.exception.PrimaryMasterExistenteException;
+import com.mypetadmin.ps_user.exception.PrimeiroMasterProtegidoException;
+import com.mypetadmin.ps_user.exception.UsuarioNaoEncontradoException;
+import com.mypetadmin.ps_user.exception.UsuarioOperacaoNaoPermitidaException;
 import com.mypetadmin.ps_user.mapper.UsuarioMapper;
 import com.mypetadmin.ps_user.repository.UsuarioRepository;
 import feign.FeignException;
@@ -20,14 +25,24 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UsuarioServiceImpl implements UsuarioService {
+
+    private static final Set<RoleUsuario> ROLES_OPERACIONAIS = EnumSet.of(
+            RoleUsuario.LOJA,
+            RoleUsuario.VETERINARIO,
+            RoleUsuario.BANHO,
+            RoleUsuario.HOTEL,
+            RoleUsuario.CRECHE
+    );
 
     private final UsuarioRepository usuarioRepository;
     private final UsuarioMapper usuarioMapper;
@@ -45,18 +60,17 @@ public class UsuarioServiceImpl implements UsuarioService {
 
         validarEmpresa(request.empresaId());
 
+        if (usuarioRepository.existsByEmpresaIdAndPrimaryMasterTrue(request.empresaId())) {
+            throw new PrimaryMasterExistenteException();
+        }
+
         if (usuarioRepository.existsByEmailIgnoreCase(emailNormalizado)) {
             throw new EmailExistenteException();
         }
 
-        Usuario usuario = new Usuario();
-        usuario.setEmpresaId(request.empresaId());
+        Usuario usuario = novoUsuario(request.empresaId(), request.nome(), emailNormalizado, RoleUsuario.MASTER);
         usuario.setOnboardingId(request.onboardingId());
-        usuario.setNome(request.nome().trim());
-        usuario.setEmail(emailNormalizado);
-        usuario.setStatus(StatusUsuario.ATIVO);
-        usuario.setRoles(new HashSet<>());
-        usuario.getRoles().add(RoleUsuario.MASTER);
+        usuario.setPrimaryMaster(true);
 
         try {
             Usuario salvo = usuarioRepository.saveAndFlush(usuario);
@@ -68,9 +82,104 @@ public class UsuarioServiceImpl implements UsuarioService {
             if (concorrente.isPresent()) {
                 return validarReplay(concorrente.get(), request, emailNormalizado);
             }
+            if (usuarioRepository.existsByEmpresaIdAndPrimaryMasterTrue(request.empresaId())) {
+                throw new PrimaryMasterExistenteException();
+            }
             log.warn("user.master.conflict empresaId={} onboardingId={}", request.empresaId(), request.onboardingId());
             throw new EmailExistenteException();
         }
+    }
+
+    @Override
+    @Transactional
+    public UsuarioResponseDTO criarUsuario(UUID actorUserId, UsuarioCreateRequestDTO request) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        RoleUsuario actorRole = roleUnica(actor);
+        validarRolePermitidaParaCriacao(actorRole, request.role());
+
+        String emailNormalizado = normalizeEmail(request.email());
+        if (usuarioRepository.existsByEmailIgnoreCase(emailNormalizado)) {
+            throw new EmailExistenteException();
+        }
+
+        Usuario usuario = novoUsuario(actor.getEmpresaId(), request.nome(), emailNormalizado, request.role());
+        usuario.setPrimaryMaster(false);
+
+        try {
+            Usuario salvo = usuarioRepository.saveAndFlush(usuario);
+            log.info("user.created actorUserId={} userId={} empresaId={} role={}",
+                    actor.getId(), salvo.getId(), salvo.getEmpresaId(), request.role());
+            return usuarioMapper.toResponse(salvo);
+        } catch (DataIntegrityViolationException ex) {
+            throw new EmailExistenteException();
+        }
+    }
+
+    @Override
+    @Transactional
+    public void excluirUsuario(UUID actorUserId, UUID usuarioId) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        Usuario alvo = usuarioRepository.findByIdAndEmpresaId(usuarioId, actor.getEmpresaId())
+                .orElseThrow(UsuarioNaoEncontradoException::new);
+
+        if (alvo.isPrimaryMaster()) {
+            throw new PrimeiroMasterProtegidoException();
+        }
+
+        RoleUsuario actorRole = roleUnica(actor);
+        RoleUsuario alvoRole = roleUnica(alvo);
+        validarPodeExcluir(actorRole, alvoRole);
+
+        usuarioRepository.delete(alvo);
+        log.info("user.deleted actorUserId={} userId={} empresaId={} targetRole={}",
+                actor.getId(), alvo.getId(), alvo.getEmpresaId(), alvoRole);
+    }
+
+    private Usuario novoUsuario(UUID empresaId, String nome, String emailNormalizado, RoleUsuario role) {
+        Usuario usuario = new Usuario();
+        usuario.setEmpresaId(empresaId);
+        usuario.setNome(nome.trim());
+        usuario.setEmail(emailNormalizado);
+        usuario.setStatus(StatusUsuario.ATIVO);
+        usuario.setRoles(new HashSet<>());
+        usuario.getRoles().add(role);
+        return usuario;
+    }
+
+    private Usuario carregarActorAtivo(UUID actorUserId) {
+        Usuario actor = usuarioRepository.findById(actorUserId)
+                .orElseThrow(UsuarioNaoEncontradoException::new);
+        if (actor.getStatus() != StatusUsuario.ATIVO) {
+            throw new UsuarioOperacaoNaoPermitidaException();
+        }
+        return actor;
+    }
+
+    private void validarRolePermitidaParaCriacao(RoleUsuario actorRole, RoleUsuario novaRole) {
+        if (actorRole == RoleUsuario.MASTER) {
+            return;
+        }
+        if (actorRole == RoleUsuario.ADMIN && ROLES_OPERACIONAIS.contains(novaRole)) {
+            return;
+        }
+        throw new UsuarioOperacaoNaoPermitidaException();
+    }
+
+    private void validarPodeExcluir(RoleUsuario actorRole, RoleUsuario alvoRole) {
+        if (actorRole == RoleUsuario.MASTER) {
+            return;
+        }
+        if (actorRole == RoleUsuario.ADMIN && ROLES_OPERACIONAIS.contains(alvoRole)) {
+            return;
+        }
+        throw new UsuarioOperacaoNaoPermitidaException();
+    }
+
+    private RoleUsuario roleUnica(Usuario usuario) {
+        if (usuario.getRoles() == null || usuario.getRoles().size() != 1) {
+            throw new UsuarioOperacaoNaoPermitidaException();
+        }
+        return usuario.getRoles().iterator().next();
     }
 
     private UsuarioResponseDTO validarReplay(Usuario usuario,

--- a/src/main/resources/db/migration/V2__user_roles_and_primary_master.sql
+++ b/src/main/resources/db/migration/V2__user_roles_and_primary_master.sql
@@ -1,0 +1,24 @@
+ALTER TABLE usuarios
+    ADD COLUMN primary_master BOOLEAN NOT NULL DEFAULT FALSE;
+
+WITH primeiros_masters AS (
+    SELECT DISTINCT ON (u.empresa_id) u.id
+    FROM usuarios u
+    JOIN usuario_roles ur ON ur.usuario_id = u.id
+    WHERE ur.role = 'MASTER'
+    ORDER BY u.empresa_id, u.data_criacao, u.id
+)
+UPDATE usuarios
+SET primary_master = TRUE
+WHERE id IN (SELECT id FROM primeiros_masters);
+
+CREATE UNIQUE INDEX uk_usuarios_primary_master_empresa
+    ON usuarios (empresa_id)
+    WHERE primary_master = TRUE;
+
+ALTER TABLE usuario_roles
+    DROP CONSTRAINT ck_usuario_roles_role;
+
+ALTER TABLE usuario_roles
+    ADD CONSTRAINT ck_usuario_roles_role
+    CHECK (role IN ('MASTER', 'ADMIN', 'LOJA', 'VETERINARIO', 'BANHO', 'HOTEL', 'CRECHE'));

--- a/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioControllerSecurityTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioControllerSecurityTest.java
@@ -5,6 +5,7 @@ import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.enums.RoleUsuario;
 import com.mypetadmin.ps_user.enums.StatusUsuario;
 import com.mypetadmin.ps_user.exception.GlobalExceptionHandler;
+import com.mypetadmin.ps_user.exception.UsuarioOperacaoNaoPermitidaException;
 import com.mypetadmin.ps_user.security.InternalRequestFilter;
 import com.mypetadmin.ps_user.security.SecurityConfig;
 import com.mypetadmin.ps_user.service.UsuarioService;
@@ -23,6 +24,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -44,7 +46,7 @@ class InternalUsuarioControllerSecurityTest {
     void deveRejeitarEndpointInternoSemChave() throws Exception {
         mockMvc.perform(post("/internal/usuarios/master")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(validBody()))
+                        .content(validMasterBody()))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("unauthorized"));
     }
@@ -54,7 +56,7 @@ class InternalUsuarioControllerSecurityTest {
         mockMvc.perform(post("/internal/usuarios/master")
                         .header("X-Internal-Key", "wrong")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(validBody()))
+                        .content(validMasterBody()))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -62,19 +64,78 @@ class InternalUsuarioControllerSecurityTest {
     void deveCriarMasterComChaveInternaValidaECorrelationId() throws Exception {
         UUID userId = UUID.randomUUID();
         UUID empresaId = UUID.randomUUID();
-        when(usuarioService.criarMaster(any())).thenReturn(new UsuarioResponseDTO(
-                userId, empresaId, "Master", "master@example.com", StatusUsuario.ATIVO,
-                Set.of(RoleUsuario.MASTER), OffsetDateTime.now(), OffsetDateTime.now()));
+        when(usuarioService.criarMaster(any())).thenReturn(response(userId, empresaId, RoleUsuario.MASTER, true));
 
         mockMvc.perform(post("/internal/usuarios/master")
                         .header("X-Internal-Key", "test-key")
                         .header("X-Correlation-Id", "corr-123")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(validBody(empresaId)))
+                        .content(validMasterBody(empresaId)))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("X-Correlation-Id", "corr-123"))
                 .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.primaryMaster").value(true))
                 .andExpect(jsonPath("$.roles[0]").value("MASTER"));
+    }
+
+    @Test
+    void deveCriarUsuarioGerenciadoComActorInterno() throws Exception {
+        UUID actorId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID empresaId = UUID.randomUUID();
+        when(usuarioService.criarUsuario(any(), any())).thenReturn(response(userId, empresaId, RoleUsuario.LOJA, false));
+
+        mockMvc.perform(post("/internal/usuarios")
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nome\":\"Loja\",\"email\":\"loja@example.com\",\"role\":\"LOJA\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.primaryMaster").value(false))
+                .andExpect(jsonPath("$.roles[0]").value("LOJA"));
+    }
+
+    @Test
+    void deveExcluirUsuarioGerenciadoComActorInterno() throws Exception {
+        mockMvc.perform(delete("/internal/usuarios/{id}", UUID.randomUUID())
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", UUID.randomUUID().toString()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deveExigirActorNasOperacoesGerenciadas() throws Exception {
+        mockMvc.perform(post("/internal/usuarios")
+                        .header("X-Internal-Key", "test-key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nome\":\"Loja\",\"email\":\"loja@example.com\",\"role\":\"LOJA\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("USER_BAD_REQUEST"));
+    }
+
+    @Test
+    void deveMapearRoleInvalidaComoBadRequest() throws Exception {
+        mockMvc.perform(post("/internal/usuarios")
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nome\":\"Loja\",\"email\":\"loja@example.com\",\"role\":\"SUPER_ADMIN\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("USER_BAD_REQUEST"));
+    }
+
+    @Test
+    void deveMapearPermissaoNegadaComo403() throws Exception {
+        when(usuarioService.criarUsuario(any(), any())).thenThrow(new UsuarioOperacaoNaoPermitidaException());
+
+        mockMvc.perform(post("/internal/usuarios")
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", UUID.randomUUID().toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nome\":\"Admin\",\"email\":\"admin@example.com\",\"role\":\"ADMIN\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_OPERATION_FORBIDDEN"));
     }
 
     @Test
@@ -99,11 +160,25 @@ class InternalUsuarioControllerSecurityTest {
                 .andExpect(status().isUnauthorized());
     }
 
-    private String validBody() {
-        return validBody(UUID.randomUUID());
+    private UsuarioResponseDTO response(UUID userId, UUID empresaId, RoleUsuario role, boolean primaryMaster) {
+        return new UsuarioResponseDTO(
+                userId,
+                empresaId,
+                "Usuário",
+                "usuario@example.com",
+                StatusUsuario.ATIVO,
+                primaryMaster,
+                Set.of(role),
+                OffsetDateTime.now(),
+                OffsetDateTime.now()
+        );
     }
 
-    private String validBody(UUID empresaId) {
+    private String validMasterBody() {
+        return validMasterBody(UUID.randomUUID());
+    }
+
+    private String validMasterBody(UUID empresaId) {
         return "{\"empresaId\":\"" + empresaId + "\",\"onboardingId\":\"" + UUID.randomUUID()
                 + "\",\"nome\":\"Master\",\"email\":\"master@example.com\"}";
     }

--- a/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerTest.java
@@ -1,9 +1,9 @@
 package com.mypetadmin.ps_user.exception;
 
-import jakarta.servlet.ServletRequestBindingException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.ServletRequestBindingException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerTest.java
@@ -1,5 +1,6 @@
 package com.mypetadmin.ps_user.exception;
 
+import jakarta.servlet.ServletRequestBindingException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -14,12 +15,26 @@ class GlobalExceptionHandlerTest {
     void deveMapearConflitosDeDominio() {
         assertResponse(handler.handleEmail(new EmailExistenteException(), request()), HttpStatus.CONFLICT, "USER_EMAIL_EXISTS");
         assertResponse(handler.handleOnboarding(new OnboardingConflictException(), request()), HttpStatus.CONFLICT, "USER_ONBOARDING_CONFLICT");
+        assertResponse(handler.handlePrimaryMasterExists(new PrimaryMasterExistenteException(), request()), HttpStatus.CONFLICT, "USER_PRIMARY_MASTER_EXISTS");
+        assertResponse(handler.handlePrimaryMasterProtected(new PrimeiroMasterProtegidoException(), request()), HttpStatus.CONFLICT, "USER_PRIMARY_MASTER_PROTECTED");
+    }
+
+    @Test
+    void deveMapearErrosDeGestao() {
+        assertResponse(handler.handleUserNotFound(new UsuarioNaoEncontradoException(), request()), HttpStatus.NOT_FOUND, "USER_NOT_FOUND");
+        assertResponse(handler.handleUserForbidden(new UsuarioOperacaoNaoPermitidaException(), request()), HttpStatus.FORBIDDEN, "USER_OPERATION_FORBIDDEN");
     }
 
     @Test
     void deveMapearFalhasDeEmpresa() {
         assertResponse(handler.handleEmpresaNotFound(new EmpresaNaoEncontradaException(), request()), HttpStatus.UNPROCESSABLE_ENTITY, "USER_EMPRESA_NOT_FOUND");
         assertResponse(handler.handleEmpresaUnavailable(new EmpresaIndisponivelException(), request()), HttpStatus.SERVICE_UNAVAILABLE, "USER_EMPRESA_UNAVAILABLE");
+    }
+
+    @Test
+    void deveMapearRequisicaoMalformada() {
+        assertResponse(handler.handleBadRequest(new ServletRequestBindingException("header ausente"), request()),
+                HttpStatus.BAD_REQUEST, "USER_BAD_REQUEST");
     }
 
     @Test
@@ -30,8 +45,7 @@ class GlobalExceptionHandlerTest {
     }
 
     private MockHttpServletRequest request() {
-        var request = new MockHttpServletRequest("POST", "/internal/usuarios/master");
-        return request;
+        return new MockHttpServletRequest("POST", "/internal/usuarios/master");
     }
 
     private void assertResponse(org.springframework.http.ResponseEntity<ErrorResponse> response,

--- a/src/test/java/com/mypetadmin/ps_user/service/UsuarioServiceImplTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/service/UsuarioServiceImplTest.java
@@ -2,6 +2,7 @@ package com.mypetadmin.ps_user.service;
 
 import com.mypetadmin.ps_user.client.EmpresaClient;
 import com.mypetadmin.ps_user.dto.EmpresaStatusResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.entity.Usuario;
 import com.mypetadmin.ps_user.enums.RoleUsuario;
@@ -10,18 +11,25 @@ import com.mypetadmin.ps_user.exception.EmailExistenteException;
 import com.mypetadmin.ps_user.exception.EmpresaIndisponivelException;
 import com.mypetadmin.ps_user.exception.EmpresaNaoEncontradaException;
 import com.mypetadmin.ps_user.exception.OnboardingConflictException;
+import com.mypetadmin.ps_user.exception.PrimaryMasterExistenteException;
+import com.mypetadmin.ps_user.exception.PrimeiroMasterProtegidoException;
+import com.mypetadmin.ps_user.exception.UsuarioNaoEncontradoException;
+import com.mypetadmin.ps_user.exception.UsuarioOperacaoNaoPermitidaException;
 import com.mypetadmin.ps_user.mapper.UsuarioMapper;
 import com.mypetadmin.ps_user.repository.UsuarioRepository;
 import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +53,7 @@ class UsuarioServiceImplTest {
     }
 
     @Test
-    void deveCriarMasterNormalizandoEmail() {
+    void deveCriarPrimaryMasterNormalizandoEmail() {
         UUID empresaId = UUID.randomUUID();
         UUID onboardingId = UUID.randomUUID();
         var request = new UsuarioMasterCreateRequestDTO(empresaId, onboardingId, "  Luis  ", " LUIS@EXAMPLE.COM ");
@@ -53,18 +61,220 @@ class UsuarioServiceImplTest {
         when(repository.findByOnboardingId(onboardingId)).thenReturn(Optional.empty());
         when(empresaClient.buscarStatusEmpresa(empresaId)).thenReturn(new EmpresaStatusResponseDTO(empresaId, "AGUARDANDO_CONTRATO"));
         when(repository.existsByEmailIgnoreCase("luis@example.com")).thenReturn(false);
-        when(repository.saveAndFlush(any(Usuario.class))).thenAnswer(invocation -> {
-            Usuario usuario = invocation.getArgument(0);
-            usuario.setId(UUID.randomUUID());
-            return usuario;
-        });
+        mockSave();
 
         var response = service.criarMaster(request);
 
         assertThat(response.email()).isEqualTo("luis@example.com");
         assertThat(response.nome()).isEqualTo("Luis");
         assertThat(response.status()).isEqualTo(StatusUsuario.ATIVO);
+        assertThat(response.primaryMaster()).isTrue();
         assertThat(response.roles()).containsExactly(RoleUsuario.MASTER);
+    }
+
+    @Test
+    void deveImpedirSegundoPrimaryMasterDaEmpresa() {
+        UUID empresaId = UUID.randomUUID();
+        UUID onboardingId = UUID.randomUUID();
+        when(repository.findByOnboardingId(onboardingId)).thenReturn(Optional.empty());
+        when(empresaClient.buscarStatusEmpresa(empresaId)).thenReturn(new EmpresaStatusResponseDTO(empresaId, "ATIVO"));
+        when(repository.existsByEmpresaIdAndPrimaryMasterTrue(empresaId)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.criarMaster(request(empresaId, onboardingId)))
+                .isInstanceOf(PrimaryMasterExistenteException.class);
+        verify(repository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void deveDetectarCorridaDePrimaryMaster() {
+        UUID empresaId = UUID.randomUUID();
+        UUID onboardingId = UUID.randomUUID();
+        when(repository.findByOnboardingId(onboardingId)).thenReturn(Optional.empty(), Optional.empty());
+        when(empresaClient.buscarStatusEmpresa(empresaId)).thenReturn(new EmpresaStatusResponseDTO(empresaId, "ATIVO"));
+        when(repository.existsByEmpresaIdAndPrimaryMasterTrue(empresaId)).thenReturn(false, true);
+        when(repository.existsByEmailIgnoreCase("master@example.com")).thenReturn(false);
+        when(repository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("primary master race"));
+
+        assertThatThrownBy(() -> service.criarMaster(request(empresaId, onboardingId)))
+                .isInstanceOf(PrimaryMasterExistenteException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(RoleUsuario.class)
+    void masterPodeCriarQualquerPerfil(RoleUsuario novaRole) {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        mockSave();
+
+        var response = service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Novo Usuário", " NOVO@EXAMPLE.COM ", novaRole));
+
+        assertThat(response.empresaId()).isEqualTo(actor.getEmpresaId());
+        assertThat(response.email()).isEqualTo("novo@example.com");
+        assertThat(response.primaryMaster()).isFalse();
+        assertThat(response.roles()).containsExactly(novaRole);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RoleUsuario.class, names = {"LOJA", "VETERINARIO", "BANHO", "HOTEL", "CRECHE"})
+    void adminPodeCriarSomentePerfisOperacionais(RoleUsuario novaRole) {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        mockSave();
+
+        var response = service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Operacional", "operacional@example.com", novaRole));
+
+        assertThat(response.roles()).containsExactly(novaRole);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RoleUsuario.class, names = {"MASTER", "ADMIN"})
+    void adminNaoPodeCriarMasterNemAdmin(RoleUsuario novaRole) {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Bloqueado", "bloqueado@example.com", novaRole)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+        verify(repository, never()).saveAndFlush(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RoleUsuario.class, names = {"LOJA", "VETERINARIO", "BANHO", "HOTEL", "CRECHE"})
+    void perfilOperacionalNaoPodeCriarUsuario(RoleUsuario actorRole) {
+        Usuario actor = usuario(actorRole, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Bloqueado", "bloqueado@example.com", RoleUsuario.LOJA)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+    }
+
+    @Test
+    void usuarioInativoNaoPodeGerenciarUsuarios() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.INATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Novo", "novo@example.com", RoleUsuario.ADMIN)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+    }
+
+    @Test
+    void deveRejeitarActorInexistente() {
+        UUID actorId = UUID.randomUUID();
+        when(repository.findById(actorId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.criarUsuario(actorId, new UsuarioCreateRequestDTO(
+                "Novo", "novo@example.com", RoleUsuario.LOJA)))
+                .isInstanceOf(UsuarioNaoEncontradoException.class);
+    }
+
+    @Test
+    void deveRejeitarEmailDuplicadoNaCriacaoGerenciada() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.existsByEmailIgnoreCase("duplicado@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Duplicado", "duplicado@example.com", RoleUsuario.ADMIN)))
+                .isInstanceOf(EmailExistenteException.class);
+    }
+
+    @Test
+    void deveTraduzirConflitoDeBancoNaCriacaoGerenciadaComoEmailDuplicado() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.saveAndFlush(any())).thenThrow(new DataIntegrityViolationException("unique"));
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Duplicado", "duplicado@example.com", RoleUsuario.LOJA)))
+                .isInstanceOf(EmailExistenteException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(RoleUsuario.class)
+    void masterPodeExcluirQualquerPerfilExcetoPrimaryMaster(RoleUsuario alvoRole) {
+        Usuario actor = usuario(RoleUsuario.MASTER, true, StatusUsuario.ATIVO);
+        Usuario alvo = usuario(actor.getEmpresaId(), alvoRole, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        service.excluirUsuario(actor.getId(), alvo.getId());
+
+        verify(repository).delete(alvo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RoleUsuario.class, names = {"LOJA", "VETERINARIO", "BANHO", "HOTEL", "CRECHE"})
+    void adminPodeExcluirPerfisOperacionais(RoleUsuario alvoRole) {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false, StatusUsuario.ATIVO);
+        Usuario alvo = usuario(actor.getEmpresaId(), alvoRole, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        service.excluirUsuario(actor.getId(), alvo.getId());
+
+        verify(repository).delete(alvo);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RoleUsuario.class, names = {"MASTER", "ADMIN"})
+    void adminNaoPodeExcluirMasterNemAdmin(RoleUsuario alvoRole) {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false, StatusUsuario.ATIVO);
+        Usuario alvo = usuario(actor.getEmpresaId(), alvoRole, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        assertThatThrownBy(() -> service.excluirUsuario(actor.getId(), alvo.getId()))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void perfilOperacionalNaoPodeExcluirUsuario() {
+        Usuario actor = usuario(RoleUsuario.LOJA, false, StatusUsuario.ATIVO);
+        Usuario alvo = usuario(actor.getEmpresaId(), RoleUsuario.CRECHE, false, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        assertThatThrownBy(() -> service.excluirUsuario(actor.getId(), alvo.getId()))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+    }
+
+    @Test
+    void ninguemPodeExcluirPrimaryMaster() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        Usuario alvo = usuario(actor.getEmpresaId(), RoleUsuario.MASTER, true, StatusUsuario.ATIVO);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        assertThatThrownBy(() -> service.excluirUsuario(actor.getId(), alvo.getId()))
+                .isInstanceOf(PrimeiroMasterProtegidoException.class);
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void naoPodeExcluirUsuarioDeOutraEmpresa() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        UUID alvoId = UUID.randomUUID();
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvoId, actor.getEmpresaId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.excluirUsuario(actor.getId(), alvoId))
+                .isInstanceOf(UsuarioNaoEncontradoException.class);
+    }
+
+    @Test
+    void deveRejeitarUsuarioComMaisDeUmaRoleNaGestao() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false, StatusUsuario.ATIVO);
+        actor.setRoles(new HashSet<>(Set.of(RoleUsuario.MASTER, RoleUsuario.ADMIN)));
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.criarUsuario(actor.getId(), new UsuarioCreateRequestDTO(
+                "Novo", "novo@example.com", RoleUsuario.LOJA)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
     }
 
     @Test
@@ -105,15 +315,14 @@ class UsuarioServiceImplTest {
     }
 
     @Test
-    void deveRejeitarEmailDuplicado() {
+    void deveRejeitarEmailDuplicadoNoOnboarding() {
         UUID empresaId = UUID.randomUUID();
         UUID onboardingId = UUID.randomUUID();
         when(repository.findByOnboardingId(onboardingId)).thenReturn(Optional.empty());
         when(empresaClient.buscarStatusEmpresa(empresaId)).thenReturn(new EmpresaStatusResponseDTO(empresaId, "ATIVO"));
         when(repository.existsByEmailIgnoreCase("master@example.com")).thenReturn(true);
 
-        assertThatThrownBy(() -> service.criarMaster(new UsuarioMasterCreateRequestDTO(
-                empresaId, onboardingId, "Master", "master@example.com")))
+        assertThatThrownBy(() -> service.criarMaster(request(empresaId, onboardingId)))
                 .isInstanceOf(EmailExistenteException.class);
     }
 
@@ -191,20 +400,40 @@ class UsuarioServiceImplTest {
                 .isInstanceOf(EmailExistenteException.class);
     }
 
+    private void mockSave() {
+        when(repository.saveAndFlush(any(Usuario.class))).thenAnswer(invocation -> {
+            Usuario usuario = invocation.getArgument(0);
+            usuario.setId(UUID.randomUUID());
+            return usuario;
+        });
+    }
+
     private UsuarioMasterCreateRequestDTO request(UUID empresaId, UUID onboardingId) {
         return new UsuarioMasterCreateRequestDTO(empresaId, onboardingId, "Master", "master@example.com");
     }
 
-    private Usuario usuarioExistente(UUID empresaId, UUID onboardingId, String email) {
+    private Usuario usuario(RoleUsuario role, boolean primaryMaster, StatusUsuario status) {
+        return usuario(UUID.randomUUID(), role, primaryMaster, status);
+    }
+
+    private Usuario usuario(UUID empresaId, RoleUsuario role, boolean primaryMaster, StatusUsuario status) {
         Usuario usuario = new Usuario();
         usuario.setId(UUID.randomUUID());
         usuario.setEmpresaId(empresaId);
+        usuario.setNome("Usuário");
+        usuario.setEmail(UUID.randomUUID() + "@example.com");
+        usuario.setStatus(status);
+        usuario.setPrimaryMaster(primaryMaster);
+        usuario.setRoles(new HashSet<>());
+        usuario.getRoles().add(role);
+        return usuario;
+    }
+
+    private Usuario usuarioExistente(UUID empresaId, UUID onboardingId, String email) {
+        Usuario usuario = usuario(empresaId, RoleUsuario.MASTER, true, StatusUsuario.ATIVO);
         usuario.setOnboardingId(onboardingId);
         usuario.setNome("Master");
         usuario.setEmail(email);
-        usuario.setStatus(StatusUsuario.ATIVO);
-        usuario.setRoles(new HashSet<>());
-        usuario.getRoles().add(RoleUsuario.MASTER);
         return usuario;
     }
 }


### PR DESCRIPTION
## Objetivo
Implementar a primeira etapa das regras oficiais de gestão de usuários do My Pet Admin.

## Incluído
- roles oficiais: MASTER, ADMIN, LOJA, VETERINARIO, BANHO, HOTEL e CRECHE;
- identificação explícita do primeiro MASTER por `primaryMaster`;
- Flyway V2 com proteção de um único primeiro MASTER por empresa;
- onboarding cria o primeiro MASTER com `primaryMaster=true`;
- MASTER pode criar todos os perfis;
- ADMIN pode criar apenas LOJA, VETERINARIO, BANHO, HOTEL e CRECHE;
- níveis operacionais não podem criar usuários;
- MASTER pode excluir qualquer perfil, exceto o primeiro MASTER;
- ADMIN pode excluir apenas perfis operacionais;
- ADMIN não pode excluir MASTER nem ADMIN;
- níveis operacionais não podem excluir usuários;
- operações gerenciadas exigem ator interno via `X-Actor-User-Id` além de `X-Internal-Key`;
- testes de service/controller e erros HTTP.

## Fora deste PR
Consulta, listagem paginada, edição e alteração de status entram no próximo incremento após esta matriz de permissão estar estável.