### PR TITLE
feat: completa gestão administrativa do PS_User

### DIFF
--- a/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
+++ b/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
@@ -1,19 +1,28 @@
 package com.mypetadmin.ps_user.controller;
 
+import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioStatusUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioUpdateRequestDTO;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
 import com.mypetadmin.ps_user.service.UsuarioService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -37,6 +46,52 @@ public class InternalUsuarioController {
             @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
             @Valid @RequestBody UsuarioCreateRequestDTO request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(usuarioService.criarUsuario(actorUserId, request));
+    }
+
+    @GetMapping("/{usuarioId}")
+    public ResponseEntity<UsuarioResponseDTO> buscarUsuario(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @PathVariable UUID usuarioId) {
+        return ResponseEntity.ok(usuarioService.buscarUsuario(actorUserId, usuarioId));
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<UsuarioResponseDTO>> listarUsuarios(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @RequestParam(required = false) String nome,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) StatusUsuario status,
+            @RequestParam(required = false) RoleUsuario role,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "nome") String sortBy,
+            @RequestParam(defaultValue = "asc") String sortDirection) {
+        return ResponseEntity.ok(usuarioService.listarUsuarios(
+                actorUserId, nome, email, status, role, page, size, sortBy, sortDirection));
+    }
+
+    @PatchMapping("/{usuarioId}")
+    public ResponseEntity<UsuarioResponseDTO> atualizarUsuario(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @PathVariable UUID usuarioId,
+            @Valid @RequestBody UsuarioUpdateRequestDTO request) {
+        return ResponseEntity.ok(usuarioService.atualizarUsuario(actorUserId, usuarioId, request));
+    }
+
+    @PatchMapping("/{usuarioId}/status")
+    public ResponseEntity<UsuarioResponseDTO> atualizarStatus(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @PathVariable UUID usuarioId,
+            @Valid @RequestBody UsuarioStatusUpdateRequestDTO request) {
+        return ResponseEntity.ok(usuarioService.atualizarStatus(actorUserId, usuarioId, request));
+    }
+
+    @PatchMapping("/{usuarioId}/role")
+    public ResponseEntity<UsuarioResponseDTO> atualizarRole(
+            @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
+            @PathVariable UUID usuarioId,
+            @Valid @RequestBody UsuarioRoleUpdateRequestDTO request) {
+        return ResponseEntity.ok(usuarioService.atualizarRole(actorUserId, usuarioId, request));
     }
 
     @DeleteMapping("/{usuarioId}")

--- a/src/main/java/com/mypetadmin/ps_user/dto/PageResponseDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/PageResponseDTO.java
@@ -1,0 +1,12 @@
+package com.mypetadmin.ps_user.dto;
+
+import java.util.List;
+
+public record PageResponseDTO<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioRoleUpdateRequestDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioRoleUpdateRequestDTO.java
@@ -1,0 +1,9 @@
+package com.mypetadmin.ps_user.dto;
+
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import jakarta.validation.constraints.NotNull;
+
+public record UsuarioRoleUpdateRequestDTO(
+        @NotNull RoleUsuario role
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioStatusUpdateRequestDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioStatusUpdateRequestDTO.java
@@ -1,0 +1,9 @@
+package com.mypetadmin.ps_user.dto;
+
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import jakarta.validation.constraints.NotNull;
+
+public record UsuarioStatusUpdateRequestDTO(
+        @NotNull StatusUsuario status
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioUpdateRequestDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioUpdateRequestDTO.java
@@ -1,0 +1,10 @@
+package com.mypetadmin.ps_user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public record UsuarioUpdateRequestDTO(
+        @Size(max = 150) String nome,
+        @Email @Size(max = 320) String email
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandler.java
@@ -48,6 +48,11 @@ public class GlobalExceptionHandler {
         return build(HttpStatus.FORBIDDEN, "USER_OPERATION_FORBIDDEN", ex, request);
     }
 
+    @ExceptionHandler(UsuarioRequisicaoInvalidaException.class)
+    ResponseEntity<ErrorResponse> handleUserBadRequest(UsuarioRequisicaoInvalidaException ex, HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, "USER_INVALID_REQUEST", ex, request);
+    }
+
     @ExceptionHandler(EmpresaNaoEncontradaException.class)
     ResponseEntity<ErrorResponse> handleEmpresaNotFound(EmpresaNaoEncontradaException ex, HttpServletRequest request) {
         return build(HttpStatus.UNPROCESSABLE_ENTITY, "USER_EMPRESA_NOT_FOUND", ex, request);

--- a/src/main/java/com/mypetadmin/ps_user/exception/UsuarioRequisicaoInvalidaException.java
+++ b/src/main/java/com/mypetadmin/ps_user/exception/UsuarioRequisicaoInvalidaException.java
@@ -1,0 +1,7 @@
+package com.mypetadmin.ps_user.exception;
+
+public class UsuarioRequisicaoInvalidaException extends RuntimeException {
+    public UsuarioRequisicaoInvalidaException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
+++ b/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
@@ -1,7 +1,13 @@
 package com.mypetadmin.ps_user.repository;
 
 import com.mypetadmin.ps_user.entity.Usuario;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -14,5 +20,35 @@ public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
 
     boolean existsByEmailIgnoreCase(String email);
 
+    boolean existsByEmailIgnoreCaseAndIdNot(String email, UUID id);
+
     boolean existsByEmpresaIdAndPrimaryMasterTrue(UUID empresaId);
+
+    @Query(value = """
+            select distinct u
+            from Usuario u
+            left join u.roles r
+            where u.empresaId = :empresaId
+              and (:nome is null or lower(u.nome) like lower(concat('%', :nome, '%')))
+              and (:email is null or lower(u.email) like lower(concat('%', :email, '%')))
+              and (:status is null or u.status = :status)
+              and (:role is null or r = :role)
+            """,
+            countQuery = """
+            select count(distinct u)
+            from Usuario u
+            left join u.roles r
+            where u.empresaId = :empresaId
+              and (:nome is null or lower(u.nome) like lower(concat('%', :nome, '%')))
+              and (:email is null or lower(u.email) like lower(concat('%', :email, '%')))
+              and (:status is null or u.status = :status)
+              and (:role is null or r = :role)
+            """)
+    Page<Usuario> buscarPorFiltros(
+            @Param("empresaId") UUID empresaId,
+            @Param("nome") String nome,
+            @Param("email") String email,
+            @Param("status") StatusUsuario status,
+            @Param("role") RoleUsuario role,
+            Pageable pageable);
 }

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
@@ -1,8 +1,14 @@
 package com.mypetadmin.ps_user.service;
 
+import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioStatusUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioUpdateRequestDTO;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
 
 import java.util.UUID;
 
@@ -10,6 +16,25 @@ public interface UsuarioService {
     UsuarioResponseDTO criarMaster(UsuarioMasterCreateRequestDTO request);
 
     UsuarioResponseDTO criarUsuario(UUID actorUserId, UsuarioCreateRequestDTO request);
+
+    UsuarioResponseDTO buscarUsuario(UUID actorUserId, UUID usuarioId);
+
+    PageResponseDTO<UsuarioResponseDTO> listarUsuarios(
+            UUID actorUserId,
+            String nome,
+            String email,
+            StatusUsuario status,
+            RoleUsuario role,
+            int page,
+            int size,
+            String sortBy,
+            String sortDirection);
+
+    UsuarioResponseDTO atualizarUsuario(UUID actorUserId, UUID usuarioId, UsuarioUpdateRequestDTO request);
+
+    UsuarioResponseDTO atualizarStatus(UUID actorUserId, UUID usuarioId, UsuarioStatusUpdateRequestDTO request);
+
+    UsuarioResponseDTO atualizarRole(UUID actorUserId, UUID usuarioId, UsuarioRoleUpdateRequestDTO request);
 
     void excluirUsuario(UUID actorUserId, UUID usuarioId);
 }

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
@@ -2,9 +2,13 @@ package com.mypetadmin.ps_user.service;
 
 import com.mypetadmin.ps_user.client.EmpresaClient;
 import com.mypetadmin.ps_user.dto.EmpresaStatusResponseDTO;
+import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioStatusUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioUpdateRequestDTO;
 import com.mypetadmin.ps_user.entity.Usuario;
 import com.mypetadmin.ps_user.enums.RoleUsuario;
 import com.mypetadmin.ps_user.enums.StatusUsuario;
@@ -16,12 +20,16 @@ import com.mypetadmin.ps_user.exception.PrimaryMasterExistenteException;
 import com.mypetadmin.ps_user.exception.PrimeiroMasterProtegidoException;
 import com.mypetadmin.ps_user.exception.UsuarioNaoEncontradoException;
 import com.mypetadmin.ps_user.exception.UsuarioOperacaoNaoPermitidaException;
+import com.mypetadmin.ps_user.exception.UsuarioRequisicaoInvalidaException;
 import com.mypetadmin.ps_user.mapper.UsuarioMapper;
 import com.mypetadmin.ps_user.repository.UsuarioRepository;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +50,10 @@ public class UsuarioServiceImpl implements UsuarioService {
             RoleUsuario.BANHO,
             RoleUsuario.HOTEL,
             RoleUsuario.CRECHE
+    );
+
+    private static final Set<String> CAMPOS_ORDENACAO = Set.of(
+            "id", "nome", "email", "status", "dataCriacao", "dataAtualizacao"
     );
 
     private final UsuarioRepository usuarioRepository;
@@ -116,11 +128,136 @@ public class UsuarioServiceImpl implements UsuarioService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public UsuarioResponseDTO buscarUsuario(UUID actorUserId, UUID usuarioId) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        return usuarioMapper.toResponse(carregarAlvoMesmoTenant(actor, usuarioId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDTO<UsuarioResponseDTO> listarUsuarios(
+            UUID actorUserId,
+            String nome,
+            String email,
+            StatusUsuario status,
+            RoleUsuario role,
+            int page,
+            int size,
+            String sortBy,
+            String sortDirection) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        validarPaginacao(page, size);
+
+        String campoOrdenacao = normalizarCampoOrdenacao(sortBy);
+        Sort.Direction direcao = normalizarDirecao(sortDirection);
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(direcao, campoOrdenacao));
+
+        Page<UsuarioResponseDTO> resultado = usuarioRepository.buscarPorFiltros(
+                        actor.getEmpresaId(),
+                        normalizeFilter(nome),
+                        normalizeFilter(email),
+                        status,
+                        role,
+                        pageable)
+                .map(usuarioMapper::toResponse);
+
+        return new PageResponseDTO<>(
+                resultado.getContent(),
+                resultado.getNumber(),
+                resultado.getSize(),
+                resultado.getTotalElements(),
+                resultado.getTotalPages());
+    }
+
+    @Override
+    @Transactional
+    public UsuarioResponseDTO atualizarUsuario(UUID actorUserId, UUID usuarioId, UsuarioUpdateRequestDTO request) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        Usuario alvo = carregarAlvoMesmoTenant(actor, usuarioId);
+        validarPodeGerenciar(roleUnica(actor), roleUnica(alvo));
+
+        boolean alterou = false;
+        if (request.nome() != null) {
+            String nome = request.nome().trim();
+            if (nome.isEmpty()) {
+                throw new UsuarioRequisicaoInvalidaException("Nome não pode ser vazio");
+            }
+            alvo.setNome(nome);
+            alterou = true;
+        }
+
+        if (request.email() != null) {
+            String email = normalizeEmail(request.email());
+            if (email.isEmpty()) {
+                throw new UsuarioRequisicaoInvalidaException("E-mail não pode ser vazio");
+            }
+            if (!alvo.getEmail().equalsIgnoreCase(email)
+                    && usuarioRepository.existsByEmailIgnoreCaseAndIdNot(email, alvo.getId())) {
+                throw new EmailExistenteException();
+            }
+            alvo.setEmail(email);
+            alterou = true;
+        }
+
+        if (!alterou) {
+            throw new UsuarioRequisicaoInvalidaException("Informe ao menos um campo para atualização");
+        }
+
+        try {
+            Usuario salvo = usuarioRepository.saveAndFlush(alvo);
+            log.info("user.updated actorUserId={} userId={} empresaId={}", actor.getId(), salvo.getId(), salvo.getEmpresaId());
+            return usuarioMapper.toResponse(salvo);
+        } catch (DataIntegrityViolationException ex) {
+            throw new EmailExistenteException();
+        }
+    }
+
+    @Override
+    @Transactional
+    public UsuarioResponseDTO atualizarStatus(UUID actorUserId, UUID usuarioId, UsuarioStatusUpdateRequestDTO request) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        Usuario alvo = carregarAlvoMesmoTenant(actor, usuarioId);
+        validarPodeGerenciar(roleUnica(actor), roleUnica(alvo));
+
+        if (alvo.isPrimaryMaster() && request.status() == StatusUsuario.INATIVO) {
+            throw new PrimeiroMasterProtegidoException();
+        }
+
+        alvo.setStatus(request.status());
+        Usuario salvo = usuarioRepository.saveAndFlush(alvo);
+        log.info("user.status.updated actorUserId={} userId={} empresaId={} status={}",
+                actor.getId(), salvo.getId(), salvo.getEmpresaId(), salvo.getStatus());
+        return usuarioMapper.toResponse(salvo);
+    }
+
+    @Override
+    @Transactional
+    public UsuarioResponseDTO atualizarRole(UUID actorUserId, UUID usuarioId, UsuarioRoleUpdateRequestDTO request) {
+        Usuario actor = carregarActorAtivo(actorUserId);
+        Usuario alvo = carregarAlvoMesmoTenant(actor, usuarioId);
+        RoleUsuario actorRole = roleUnica(actor);
+        RoleUsuario alvoRole = roleUnica(alvo);
+
+        if (alvo.isPrimaryMaster() && request.role() != RoleUsuario.MASTER) {
+            throw new PrimeiroMasterProtegidoException();
+        }
+
+        validarRolePermitidaParaAtualizacao(actorRole, alvoRole, request.role());
+        alvo.setRoles(new HashSet<>());
+        alvo.getRoles().add(request.role());
+
+        Usuario salvo = usuarioRepository.saveAndFlush(alvo);
+        log.info("user.role.updated actorUserId={} userId={} empresaId={} oldRole={} newRole={}",
+                actor.getId(), salvo.getId(), salvo.getEmpresaId(), alvoRole, request.role());
+        return usuarioMapper.toResponse(salvo);
+    }
+
+    @Override
     @Transactional
     public void excluirUsuario(UUID actorUserId, UUID usuarioId) {
         Usuario actor = carregarActorAtivo(actorUserId);
-        Usuario alvo = usuarioRepository.findByIdAndEmpresaId(usuarioId, actor.getEmpresaId())
-                .orElseThrow(UsuarioNaoEncontradoException::new);
+        Usuario alvo = carregarAlvoMesmoTenant(actor, usuarioId);
 
         if (alvo.isPrimaryMaster()) {
             throw new PrimeiroMasterProtegidoException();
@@ -155,11 +292,38 @@ public class UsuarioServiceImpl implements UsuarioService {
         return actor;
     }
 
+    private Usuario carregarAlvoMesmoTenant(Usuario actor, UUID usuarioId) {
+        return usuarioRepository.findByIdAndEmpresaId(usuarioId, actor.getEmpresaId())
+                .orElseThrow(UsuarioNaoEncontradoException::new);
+    }
+
     private void validarRolePermitidaParaCriacao(RoleUsuario actorRole, RoleUsuario novaRole) {
         if (actorRole == RoleUsuario.MASTER) {
             return;
         }
         if (actorRole == RoleUsuario.ADMIN && ROLES_OPERACIONAIS.contains(novaRole)) {
+            return;
+        }
+        throw new UsuarioOperacaoNaoPermitidaException();
+    }
+
+    private void validarPodeGerenciar(RoleUsuario actorRole, RoleUsuario alvoRole) {
+        if (actorRole == RoleUsuario.MASTER) {
+            return;
+        }
+        if (actorRole == RoleUsuario.ADMIN && ROLES_OPERACIONAIS.contains(alvoRole)) {
+            return;
+        }
+        throw new UsuarioOperacaoNaoPermitidaException();
+    }
+
+    private void validarRolePermitidaParaAtualizacao(RoleUsuario actorRole, RoleUsuario alvoRole, RoleUsuario novaRole) {
+        if (actorRole == RoleUsuario.MASTER) {
+            return;
+        }
+        if (actorRole == RoleUsuario.ADMIN
+                && ROLES_OPERACIONAIS.contains(alvoRole)
+                && ROLES_OPERACIONAIS.contains(novaRole)) {
             return;
         }
         throw new UsuarioOperacaoNaoPermitidaException();
@@ -180,6 +344,33 @@ public class UsuarioServiceImpl implements UsuarioService {
             throw new UsuarioOperacaoNaoPermitidaException();
         }
         return usuario.getRoles().iterator().next();
+    }
+
+    private void validarPaginacao(int page, int size) {
+        if (page < 0) {
+            throw new UsuarioRequisicaoInvalidaException("Página não pode ser negativa");
+        }
+        if (size < 1 || size > 100) {
+            throw new UsuarioRequisicaoInvalidaException("Tamanho da página deve estar entre 1 e 100");
+        }
+    }
+
+    private String normalizarCampoOrdenacao(String sortBy) {
+        String campo = sortBy == null || sortBy.isBlank() ? "nome" : sortBy.trim();
+        if (!CAMPOS_ORDENACAO.contains(campo)) {
+            throw new UsuarioRequisicaoInvalidaException("Campo de ordenação inválido");
+        }
+        return campo;
+    }
+
+    private Sort.Direction normalizarDirecao(String sortDirection) {
+        if (sortDirection == null || sortDirection.isBlank() || "asc".equalsIgnoreCase(sortDirection)) {
+            return Sort.Direction.ASC;
+        }
+        if ("desc".equalsIgnoreCase(sortDirection)) {
+            return Sort.Direction.DESC;
+        }
+        throw new UsuarioRequisicaoInvalidaException("Direção de ordenação inválida");
     }
 
     private UsuarioResponseDTO validarReplay(Usuario usuario,
@@ -208,5 +399,12 @@ public class UsuarioServiceImpl implements UsuarioService {
 
     private String normalizeEmail(String email) {
         return email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeFilter(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
     }
 }

--- a/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioCrudControllerTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioCrudControllerTest.java
@@ -1,0 +1,130 @@
+package com.mypetadmin.ps_user.controller;
+
+import com.mypetadmin.ps_user.config.CorrelationIdFilter;
+import com.mypetadmin.ps_user.dto.PageResponseDTO;
+import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import com.mypetadmin.ps_user.exception.GlobalExceptionHandler;
+import com.mypetadmin.ps_user.security.InternalRequestFilter;
+import com.mypetadmin.ps_user.security.SecurityConfig;
+import com.mypetadmin.ps_user.service.UsuarioService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InternalUsuarioController.class)
+@Import({SecurityConfig.class, InternalRequestFilter.class, CorrelationIdFilter.class, GlobalExceptionHandler.class})
+@TestPropertySource(properties = {
+        "security.internal-key=test-key",
+        "clients.ps-empresa.url=http://localhost:8081"
+})
+class InternalUsuarioCrudControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean UsuarioService usuarioService;
+
+    @Test
+    void deveBuscarUsuario() throws Exception {
+        UUID actorId = UUID.randomUUID();
+        UUID usuarioId = UUID.randomUUID();
+        when(usuarioService.buscarUsuario(actorId, usuarioId)).thenReturn(response(usuarioId));
+
+        mockMvc.perform(get("/internal/usuarios/{id}", usuarioId)
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(usuarioId.toString()));
+    }
+
+    @Test
+    void deveListarUsuariosComPaginacao() throws Exception {
+        UUID actorId = UUID.randomUUID();
+        UUID usuarioId = UUID.randomUUID();
+        when(usuarioService.listarUsuarios(eq(actorId), isNull(), isNull(), isNull(), isNull(),
+                eq(0), eq(20), eq("nome"), eq("asc")))
+                .thenReturn(new PageResponseDTO<>(List.of(response(usuarioId)), 0, 20, 1, 1));
+
+        mockMvc.perform(get("/internal/usuarios")
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(usuarioId.toString()))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void deveAtualizarDadosStatusERole() throws Exception {
+        UUID actorId = UUID.randomUUID();
+        UUID usuarioId = UUID.randomUUID();
+        when(usuarioService.atualizarUsuario(eq(actorId), eq(usuarioId), any())).thenReturn(response(usuarioId));
+        when(usuarioService.atualizarStatus(eq(actorId), eq(usuarioId), any())).thenReturn(response(usuarioId));
+        when(usuarioService.atualizarRole(eq(actorId), eq(usuarioId), any())).thenReturn(response(usuarioId));
+
+        mockMvc.perform(patch("/internal/usuarios/{id}", usuarioId)
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nome\":\"Novo Nome\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/internal/usuarios/{id}/status", usuarioId)
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"INATIVO\"}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/internal/usuarios/{id}/role", usuarioId)
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", actorId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\":\"BANHO\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deveRejeitarRoleInvalidaComoBadRequest() throws Exception {
+        mockMvc.perform(patch("/internal/usuarios/{id}/role", UUID.randomUUID())
+                        .header("X-Internal-Key", "test-key")
+                        .header("X-Actor-User-Id", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\":\"SUPER_ADMIN\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("USER_BAD_REQUEST"));
+    }
+
+    private UsuarioResponseDTO response(UUID id) {
+        return new UsuarioResponseDTO(
+                id,
+                UUID.randomUUID(),
+                "Usuário",
+                "user@example.com",
+                StatusUsuario.ATIVO,
+                false,
+                Set.of(RoleUsuario.LOJA),
+                OffsetDateTime.now(),
+                OffsetDateTime.now());
+    }
+}

--- a/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerCrudTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/exception/GlobalExceptionHandlerCrudTest.java
@@ -1,0 +1,25 @@
+package com.mypetadmin.ps_user.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerCrudTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void deveMapearRequisicaoInvalidaComo400() {
+        var request = new MockHttpServletRequest("GET", "/internal/usuarios");
+
+        var response = handler.handleUserBadRequest(
+                new UsuarioRequisicaoInvalidaException("Filtro inválido"), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().code()).isEqualTo("USER_INVALID_REQUEST");
+        assertThat(response.getBody().message()).isEqualTo("Filtro inválido");
+    }
+}

--- a/src/test/java/com/mypetadmin/ps_user/service/UsuarioCrudServiceTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/service/UsuarioCrudServiceTest.java
@@ -1,0 +1,270 @@
+package com.mypetadmin.ps_user.service;
+
+import com.mypetadmin.ps_user.client.EmpresaClient;
+import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioStatusUpdateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioUpdateRequestDTO;
+import com.mypetadmin.ps_user.entity.Usuario;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import com.mypetadmin.ps_user.exception.EmailExistenteException;
+import com.mypetadmin.ps_user.exception.PrimeiroMasterProtegidoException;
+import com.mypetadmin.ps_user.exception.UsuarioNaoEncontradoException;
+import com.mypetadmin.ps_user.exception.UsuarioOperacaoNaoPermitidaException;
+import com.mypetadmin.ps_user.exception.UsuarioRequisicaoInvalidaException;
+import com.mypetadmin.ps_user.mapper.UsuarioMapper;
+import com.mypetadmin.ps_user.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioCrudServiceTest {
+
+    @Mock UsuarioRepository repository;
+    @Mock EmpresaClient empresaClient;
+    private UsuarioServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UsuarioServiceImpl(repository, new UsuarioMapper(), empresaClient);
+    }
+
+    @Test
+    void deveBuscarUsuarioSomenteNoMesmoTenant() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        var response = service.buscarUsuario(actor.getId(), alvo.getId());
+
+        assertThat(response.id()).isEqualTo(alvo.getId());
+        assertThat(response.empresaId()).isEqualTo(actor.getEmpresaId());
+    }
+
+    @Test
+    void deveOcultarUsuarioDeOutroTenantComoNaoEncontrado() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(any(), eq(actor.getEmpresaId()))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarUsuario(actor.getId(), UUID.randomUUID()))
+                .isInstanceOf(UsuarioNaoEncontradoException.class);
+    }
+
+    @Test
+    void deveListarComFiltrosPaginacaoEOrdenacao() {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false);
+        Usuario alvo = usuario(RoleUsuario.BANHO, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.buscarPorFiltros(eq(actor.getEmpresaId()), eq("Maria"), eq("pet@"),
+                eq(StatusUsuario.ATIVO), eq(RoleUsuario.BANHO), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(java.util.List.of(alvo)));
+
+        var response = service.listarUsuarios(actor.getId(), " Maria ", " pet@ ", StatusUsuario.ATIVO,
+                RoleUsuario.BANHO, 0, 10, "email", "desc");
+
+        assertThat(response.content()).hasSize(1);
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(repository).buscarPorFiltros(eq(actor.getEmpresaId()), eq("Maria"), eq("pet@"),
+                eq(StatusUsuario.ATIVO), eq(RoleUsuario.BANHO), pageable.capture());
+        assertThat(pageable.getValue().getSort().getOrderFor("email").getDirection().name()).isEqualTo("DESC");
+    }
+
+    @Test
+    void deveAplicarDefaultsNaListagem() {
+        Usuario actor = usuario(RoleUsuario.LOJA, false);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.buscarPorFiltros(eq(actor.getEmpresaId()), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(java.util.List.of()));
+
+        service.listarUsuarios(actor.getId(), " ", null, null, null, 0, 20, null, null);
+
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(repository).buscarPorFiltros(eq(actor.getEmpresaId()), eq(null), eq(null), eq(null), eq(null), pageable.capture());
+        assertThat(pageable.getValue().getSort().getOrderFor("nome").isAscending()).isTrue();
+    }
+
+    @Test
+    void deveValidarParametrosDePaginacaoEOrdenacao() {
+        Usuario actor = usuario(RoleUsuario.MASTER, false);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.listarUsuarios(actor.getId(), null, null, null, null, -1, 20, "nome", "asc"))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.listarUsuarios(actor.getId(), null, null, null, null, 0, 0, "nome", "asc"))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.listarUsuarios(actor.getId(), null, null, null, null, 0, 101, "nome", "asc"))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.listarUsuarios(actor.getId(), null, null, null, null, 0, 20, "senha", "asc"))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.listarUsuarios(actor.getId(), null, null, null, null, 0, 20, "nome", "lado"))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+    }
+
+    @Test
+    void masterDeveAtualizarNomeEEmail() {
+        Usuario actor = usuario(RoleUsuario.MASTER, true);
+        Usuario alvo = usuario(RoleUsuario.ADMIN, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+        when(repository.existsByEmailIgnoreCaseAndIdNot("novo@example.com", alvo.getId())).thenReturn(false);
+        when(repository.saveAndFlush(alvo)).thenReturn(alvo);
+
+        var response = service.atualizarUsuario(actor.getId(), alvo.getId(),
+                new UsuarioUpdateRequestDTO(" Novo Nome ", " NOVO@EXAMPLE.COM "));
+
+        assertThat(response.nome()).isEqualTo("Novo Nome");
+        assertThat(response.email()).isEqualTo("novo@example.com");
+    }
+
+    @Test
+    void deveRejeitarAtualizacaoVaziaNomeVazioEEmailVazio() {
+        Usuario actor = usuario(RoleUsuario.MASTER, true);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(), new UsuarioUpdateRequestDTO(null, null)))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(), new UsuarioUpdateRequestDTO("   ", null)))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(), new UsuarioUpdateRequestDTO(null, "   ")))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+    }
+
+    @Test
+    void deveRejeitarEmailDuplicadoInclusiveEmCorridaDeBanco() {
+        Usuario actor = usuario(RoleUsuario.MASTER, true);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+        when(repository.existsByEmailIgnoreCaseAndIdNot("duplicado@example.com", alvo.getId())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(),
+                new UsuarioUpdateRequestDTO(null, "duplicado@example.com")))
+                .isInstanceOf(EmailExistenteException.class);
+
+        when(repository.existsByEmailIgnoreCaseAndIdNot("outro@example.com", alvo.getId())).thenReturn(false);
+        when(repository.saveAndFlush(alvo)).thenThrow(new DataIntegrityViolationException("race"));
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(),
+                new UsuarioUpdateRequestDTO(null, "outro@example.com")))
+                .isInstanceOf(EmailExistenteException.class);
+    }
+
+    @Test
+    void adminPodeGerenciarApenasPerfisOperacionais() {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false);
+        Usuario operacional = usuario(RoleUsuario.CRECHE, false);
+        operacional.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(operacional.getId(), actor.getEmpresaId())).thenReturn(Optional.of(operacional));
+        when(repository.saveAndFlush(operacional)).thenReturn(operacional);
+
+        var response = service.atualizarStatus(actor.getId(), operacional.getId(),
+                new UsuarioStatusUpdateRequestDTO(StatusUsuario.INATIVO));
+        assertThat(response.status()).isEqualTo(StatusUsuario.INATIVO);
+
+        Usuario adminAlvo = usuario(RoleUsuario.ADMIN, false);
+        adminAlvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findByIdAndEmpresaId(adminAlvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(adminAlvo));
+        assertThatThrownBy(() -> service.atualizarStatus(actor.getId(), adminAlvo.getId(),
+                new UsuarioStatusUpdateRequestDTO(StatusUsuario.INATIVO)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+    }
+
+    @Test
+    void primeiroMasterNaoPodeSerInativadoNemPerderRoleMaster() {
+        Usuario actor = usuario(RoleUsuario.MASTER, true);
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(actor.getId(), actor.getEmpresaId())).thenReturn(Optional.of(actor));
+
+        assertThatThrownBy(() -> service.atualizarStatus(actor.getId(), actor.getId(),
+                new UsuarioStatusUpdateRequestDTO(StatusUsuario.INATIVO)))
+                .isInstanceOf(PrimeiroMasterProtegidoException.class);
+        assertThatThrownBy(() -> service.atualizarRole(actor.getId(), actor.getId(),
+                new UsuarioRoleUpdateRequestDTO(RoleUsuario.ADMIN)))
+                .isInstanceOf(PrimeiroMasterProtegidoException.class);
+    }
+
+    @Test
+    void masterPodeAlterarRoleDeUsuarioNaoPrimario() {
+        Usuario actor = usuario(RoleUsuario.MASTER, true);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+        when(repository.saveAndFlush(alvo)).thenReturn(alvo);
+
+        var response = service.atualizarRole(actor.getId(), alvo.getId(), new UsuarioRoleUpdateRequestDTO(RoleUsuario.ADMIN));
+
+        assertThat(response.roles()).containsExactly(RoleUsuario.ADMIN);
+    }
+
+    @Test
+    void adminPodeTrocarSomenteEntreRolesOperacionais() {
+        Usuario actor = usuario(RoleUsuario.ADMIN, false);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+        when(repository.saveAndFlush(alvo)).thenReturn(alvo);
+
+        var response = service.atualizarRole(actor.getId(), alvo.getId(), new UsuarioRoleUpdateRequestDTO(RoleUsuario.HOTEL));
+        assertThat(response.roles()).containsExactly(RoleUsuario.HOTEL);
+
+        alvo.setRoles(new HashSet<>(Set.of(RoleUsuario.LOJA)));
+        assertThatThrownBy(() -> service.atualizarRole(actor.getId(), alvo.getId(), new UsuarioRoleUpdateRequestDTO(RoleUsuario.ADMIN)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+    }
+
+    @Test
+    void perfilOperacionalNaoPodeGerenciarUsuario() {
+        Usuario actor = usuario(RoleUsuario.BANHO, false);
+        Usuario alvo = usuario(RoleUsuario.LOJA, false);
+        alvo.setEmpresaId(actor.getEmpresaId());
+        when(repository.findById(actor.getId())).thenReturn(Optional.of(actor));
+        when(repository.findByIdAndEmpresaId(alvo.getId(), actor.getEmpresaId())).thenReturn(Optional.of(alvo));
+
+        assertThatThrownBy(() -> service.atualizarUsuario(actor.getId(), alvo.getId(), new UsuarioUpdateRequestDTO("Nome", null)))
+                .isInstanceOf(UsuarioOperacaoNaoPermitidaException.class);
+        verify(repository, never()).saveAndFlush(alvo);
+    }
+
+    private Usuario usuario(RoleUsuario role, boolean primaryMaster) {
+        Usuario usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+        usuario.setEmpresaId(UUID.randomUUID());
+        usuario.setNome("Usuário");
+        usuario.setEmail(UUID.randomUUID() + "@example.com");
+        usuario.setStatus(StatusUsuario.ATIVO);
+        usuario.setPrimaryMaster(primaryMaster);
+        usuario.setRoles(new HashSet<>(Set.of(role)));
+        return usuario;
+    }
+}


### PR DESCRIPTION
## Objetivo
Completar o bloco de gestão administrativa do PS_User após a hierarquia do PR #9.

## Incluído
- consulta de usuário por ID com isolamento por empresa;
- listagem paginada por empresa;
- filtros por nome, e-mail, status e role;
- ordenação dinâmica com whitelist de campos;
- DTO próprio de paginação;
- edição de nome/e-mail;
- alteração de status;
- alteração de role;
- proteção do primeiro MASTER contra inativação e perda da role MASTER;
- MASTER gerencia todos os perfis;
- ADMIN gerencia apenas perfis operacionais e só pode trocar entre roles operacionais;
- perfis operacionais não podem executar operações administrativas;
- validação de paginação e ordenação;
- testes de service, controller e exception handler.

## Endpoints
- GET /internal/usuarios/{usuarioId}
- GET /internal/usuarios
- PATCH /internal/usuarios/{usuarioId}
- PATCH /internal/usuarios/{usuarioId}/status
- PATCH /internal/usuarios/{usuarioId}/role

## Segurança
Todas as rotas continuam protegidas por X-Internal-Key. Operações no contexto de usuário usam X-Actor-User-Id e o serviço sempre restringe o alvo ao empresaId do ator.