### PR TITLE
feat: adiciona contrato interno de identidade para PS_Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # PS_User — My Pet Admin
 
-Reconstrução do microsserviço de usuários do My Pet Admin.
+Microsserviço responsável pela identidade de negócio e gestão de usuários do My Pet Admin.
 
 ## Escopo
 
-O PS_User é responsável por identidade de negócio do usuário dentro do SaaS:
+O PS_User é responsável por:
 
 - cadastro e manutenção do perfil do usuário;
 - vínculo lógico com `empresaId`;
 - status do usuário;
 - roles/perfis de autorização;
-- criação idempotente do usuário `MASTER` durante onboarding;
-- consulta interna de dados de usuário para outros serviços, quando necessário.
+- criação idempotente do primeiro `MASTER` durante onboarding;
+- gestão administrativa respeitando a hierarquia MASTER/ADMIN;
+- consulta interna de identidade para serviços autorizados.
 
 ## Fora do escopo
 
@@ -23,7 +24,7 @@ Não pertencem ao PS_User:
 - recuperação de senha;
 - refresh token e sessão.
 
-Essas responsabilidades pertencem ao futuro PS_Login.
+Essas responsabilidades pertencem ao PS_Login.
 
 ## Arquitetura
 
@@ -37,16 +38,44 @@ Essas responsabilidades pertencem ao futuro PS_Login.
 - Swagger/OpenAPI
 - JaCoCo
 
+## Roles oficiais
+
+- `MASTER`
+- `ADMIN`
+- `LOJA`
+- `VETERINARIO`
+- `BANHO`
+- `HOTEL`
+- `CRECHE`
+
+O primeiro MASTER da empresa é identificado por `primaryMaster=true` e possui proteções adicionais de domínio.
+
 ## Integração com Empresa
 
 `empresaId` é uma referência lógica externa. Não existe FK cross-service. A existência da empresa é validada pela API interna do PS_Empresa usando `X-Internal-Key`.
 
+## Contrato para PS_Login
+
+O PS_User expõe um lookup interno mínimo para o futuro PS_Login:
+
+`GET /internal/usuarios/identity?email={email}`
+
+Proteção: `X-Internal-Key`.
+
+Resposta de identidade:
+
+- `userId`
+- `empresaId`
+- `email`
+- `status`
+- `roles`
+
+O endpoint não autentica, não valida senha e não emite JWT. Usuários inativos são retornados com `status=INATIVO`; cabe ao PS_Login impedir a autenticação.
+
 ## Banco
 
-O serviço deverá usar um banco lógico próprio, recomendado: `ps_user_db`.
+O serviço utiliza banco lógico próprio do PS_User e Flyway para versionamento de schema.
 
-## Estado da reconstrução
+## Estado atual
 
-Branch inicial: `rebuild/ps-user-v1`.
-
-A implementação antiga de User/Login é considerada legado e não é fonte para a nova arquitetura.
+A reconstrução V1, a hierarquia de usuários e o CRUD administrativo estão implementados. O PS_User permanece separado do PS_Login por responsabilidade de domínio.

--- a/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
+++ b/src/main/java/com/mypetadmin/ps_user/controller/InternalUsuarioController.java
@@ -2,6 +2,7 @@ package com.mypetadmin.ps_user.controller;
 
 import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioIdentityResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
@@ -46,6 +47,11 @@ public class InternalUsuarioController {
             @RequestHeader(ACTOR_USER_ID_HEADER) UUID actorUserId,
             @Valid @RequestBody UsuarioCreateRequestDTO request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(usuarioService.criarUsuario(actorUserId, request));
+    }
+
+    @GetMapping("/identity")
+    public ResponseEntity<UsuarioIdentityResponseDTO> buscarIdentidadePorEmail(@RequestParam String email) {
+        return ResponseEntity.ok(usuarioService.buscarIdentidadePorEmail(email));
     }
 
     @GetMapping("/{usuarioId}")

--- a/src/main/java/com/mypetadmin/ps_user/dto/UsuarioIdentityResponseDTO.java
+++ b/src/main/java/com/mypetadmin/ps_user/dto/UsuarioIdentityResponseDTO.java
@@ -1,0 +1,16 @@
+package com.mypetadmin.ps_user.dto;
+
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record UsuarioIdentityResponseDTO(
+        UUID userId,
+        UUID empresaId,
+        String email,
+        StatusUsuario status,
+        Set<RoleUsuario> roles
+) {
+}

--- a/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
+++ b/src/main/java/com/mypetadmin/ps_user/repository/UsuarioRepository.java
@@ -18,6 +18,8 @@ public interface UsuarioRepository extends JpaRepository<Usuario, UUID> {
 
     Optional<Usuario> findByIdAndEmpresaId(UUID id, UUID empresaId);
 
+    Optional<Usuario> findByEmailIgnoreCase(String email);
+
     boolean existsByEmailIgnoreCase(String email);
 
     boolean existsByEmailIgnoreCaseAndIdNot(String email, UUID id);

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioService.java
@@ -2,6 +2,7 @@ package com.mypetadmin.ps_user.service;
 
 import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioIdentityResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
@@ -16,6 +17,8 @@ public interface UsuarioService {
     UsuarioResponseDTO criarMaster(UsuarioMasterCreateRequestDTO request);
 
     UsuarioResponseDTO criarUsuario(UUID actorUserId, UsuarioCreateRequestDTO request);
+
+    UsuarioIdentityResponseDTO buscarIdentidadePorEmail(String email);
 
     UsuarioResponseDTO buscarUsuario(UUID actorUserId, UUID usuarioId);
 

--- a/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
+++ b/src/main/java/com/mypetadmin/ps_user/service/UsuarioServiceImpl.java
@@ -4,6 +4,7 @@ import com.mypetadmin.ps_user.client.EmpresaClient;
 import com.mypetadmin.ps_user.dto.EmpresaStatusResponseDTO;
 import com.mypetadmin.ps_user.dto.PageResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioCreateRequestDTO;
+import com.mypetadmin.ps_user.dto.UsuarioIdentityResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioMasterCreateRequestDTO;
 import com.mypetadmin.ps_user.dto.UsuarioResponseDTO;
 import com.mypetadmin.ps_user.dto.UsuarioRoleUpdateRequestDTO;
@@ -125,6 +126,25 @@ public class UsuarioServiceImpl implements UsuarioService {
         } catch (DataIntegrityViolationException ex) {
             throw new EmailExistenteException();
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UsuarioIdentityResponseDTO buscarIdentidadePorEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new UsuarioRequisicaoInvalidaException("E-mail é obrigatório");
+        }
+
+        String emailNormalizado = normalizeEmail(email);
+        Usuario usuario = usuarioRepository.findByEmailIgnoreCase(emailNormalizado)
+                .orElseThrow(UsuarioNaoEncontradoException::new);
+
+        return new UsuarioIdentityResponseDTO(
+                usuario.getId(),
+                usuario.getEmpresaId(),
+                usuario.getEmail(),
+                usuario.getStatus(),
+                Set.copyOf(usuario.getRoles()));
     }
 
     @Override

--- a/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioIdentityControllerTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/controller/InternalUsuarioIdentityControllerTest.java
@@ -1,0 +1,61 @@
+package com.mypetadmin.ps_user.controller;
+
+import com.mypetadmin.ps_user.config.CorrelationIdFilter;
+import com.mypetadmin.ps_user.dto.UsuarioIdentityResponseDTO;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import com.mypetadmin.ps_user.exception.GlobalExceptionHandler;
+import com.mypetadmin.ps_user.security.InternalRequestFilter;
+import com.mypetadmin.ps_user.security.SecurityConfig;
+import com.mypetadmin.ps_user.service.UsuarioService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = InternalUsuarioController.class)
+@Import({SecurityConfig.class, InternalRequestFilter.class, CorrelationIdFilter.class, GlobalExceptionHandler.class})
+@TestPropertySource(properties = {
+        "security.internal-key=test-key",
+        "clients.ps-empresa.url=http://localhost:8081"
+})
+class InternalUsuarioIdentityControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean UsuarioService usuarioService;
+
+    @Test
+    void deveExporIdentidadeSomenteComChaveInternaSemActorHeader() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID empresaId = UUID.randomUUID();
+        when(usuarioService.buscarIdentidadePorEmail("master@example.com")).thenReturn(
+                new UsuarioIdentityResponseDTO(userId, empresaId, "master@example.com",
+                        StatusUsuario.ATIVO, Set.of(RoleUsuario.MASTER)));
+
+        mockMvc.perform(get("/internal/usuarios/identity")
+                        .header("X-Internal-Key", "test-key")
+                        .param("email", "master@example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.empresaId").value(empresaId.toString()))
+                .andExpect(jsonPath("$.roles[0]").value("MASTER"));
+    }
+
+    @Test
+    void deveRejeitarIdentidadeSemChaveInterna() throws Exception {
+        mockMvc.perform(get("/internal/usuarios/identity")
+                        .param("email", "master@example.com"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/mypetadmin/ps_user/service/UsuarioIdentityServiceTest.java
+++ b/src/test/java/com/mypetadmin/ps_user/service/UsuarioIdentityServiceTest.java
@@ -1,0 +1,84 @@
+package com.mypetadmin.ps_user.service;
+
+import com.mypetadmin.ps_user.client.EmpresaClient;
+import com.mypetadmin.ps_user.entity.Usuario;
+import com.mypetadmin.ps_user.enums.RoleUsuario;
+import com.mypetadmin.ps_user.enums.StatusUsuario;
+import com.mypetadmin.ps_user.exception.UsuarioNaoEncontradoException;
+import com.mypetadmin.ps_user.exception.UsuarioRequisicaoInvalidaException;
+import com.mypetadmin.ps_user.mapper.UsuarioMapper;
+import com.mypetadmin.ps_user.repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioIdentityServiceTest {
+
+    @Mock UsuarioRepository repository;
+    @Mock EmpresaClient empresaClient;
+    private UsuarioServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new UsuarioServiceImpl(repository, new UsuarioMapper(), empresaClient);
+    }
+
+    @Test
+    void deveRetornarContextoMinimoParaLoginNormalizandoEmail() {
+        Usuario usuario = usuario(StatusUsuario.ATIVO, RoleUsuario.ADMIN);
+        when(repository.findByEmailIgnoreCase("admin@example.com")).thenReturn(Optional.of(usuario));
+
+        var response = service.buscarIdentidadePorEmail(" ADMIN@EXAMPLE.COM ");
+
+        assertThat(response.userId()).isEqualTo(usuario.getId());
+        assertThat(response.empresaId()).isEqualTo(usuario.getEmpresaId());
+        assertThat(response.email()).isEqualTo(usuario.getEmail());
+        assertThat(response.status()).isEqualTo(StatusUsuario.ATIVO);
+        assertThat(response.roles()).containsExactly(RoleUsuario.ADMIN);
+    }
+
+    @Test
+    void deveRetornarUsuarioInativoParaLoginDecidirBloqueio() {
+        Usuario usuario = usuario(StatusUsuario.INATIVO, RoleUsuario.LOJA);
+        when(repository.findByEmailIgnoreCase(usuario.getEmail())).thenReturn(Optional.of(usuario));
+
+        var response = service.buscarIdentidadePorEmail(usuario.getEmail());
+
+        assertThat(response.status()).isEqualTo(StatusUsuario.INATIVO);
+    }
+
+    @Test
+    void deveRejeitarEmailVazioOuUsuarioInexistente() {
+        assertThatThrownBy(() -> service.buscarIdentidadePorEmail("   "))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+        assertThatThrownBy(() -> service.buscarIdentidadePorEmail(null))
+                .isInstanceOf(UsuarioRequisicaoInvalidaException.class);
+
+        when(repository.findByEmailIgnoreCase("missing@example.com")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.buscarIdentidadePorEmail("missing@example.com"))
+                .isInstanceOf(UsuarioNaoEncontradoException.class);
+    }
+
+    private Usuario usuario(StatusUsuario status, RoleUsuario role) {
+        Usuario usuario = new Usuario();
+        usuario.setId(UUID.randomUUID());
+        usuario.setEmpresaId(UUID.randomUUID());
+        usuario.setNome("Usuário");
+        usuario.setEmail(role.name().toLowerCase() + "@example.com");
+        usuario.setStatus(status);
+        usuario.setRoles(new HashSet<>(Set.of(role)));
+        return usuario;
+    }
+}


### PR DESCRIPTION
## Objetivo
Fechar o contrato interno mínimo entre PS_User e o futuro PS_Login sem misturar responsabilidades de autenticação no domínio de usuários.

## Incluído
- GET /internal/usuarios/identity?email={email};
- lookup case-insensitive por e-mail;
- resposta mínima com userId, empresaId, email, status e roles;
- usuário INATIVO continua sendo retornado com seu status para o PS_Login negar autenticação;
- endpoint protegido por X-Internal-Key e sem necessidade de X-Actor-User-Id;
- testes de service e controller;
- README atualizado com separação explícita entre PS_User e PS_Login.

## Fora do escopo
- senha;
- autenticação;
- JWT;
- refresh token;
- recuperação de senha.

Essas responsabilidades permanecem no PS_Login.