### PR TITLE
docs: sincroniza integração com PS_Login atual

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Não pertencem ao PS_User:
 - emissão/validação de JWT;
 - armazenamento e validação de senha;
 - recuperação de senha;
-- refresh token e sessão.
+- refresh token e sessão;
+- envio de convite de ativação.
 
 Essas responsabilidades pertencem ao PS_Login.
 
@@ -50,19 +51,35 @@ Essas responsabilidades pertencem ao PS_Login.
 
 O primeiro MASTER da empresa é identificado por `primaryMaster=true` e possui proteções adicionais de domínio.
 
+### Regras de criação
+
+- o primeiro usuário do onboarding é `MASTER` e `primaryMaster=true`;
+- `MASTER` pode criar MASTER, ADMIN e perfis operacionais;
+- `ADMIN` pode criar apenas `LOJA`, `VETERINARIO`, `BANHO`, `HOTEL` e `CRECHE`;
+- `ADMIN` não pode criar MASTER nem ADMIN;
+- perfis operacionais não podem criar usuários.
+
+### Regras de exclusão
+
+- o primeiro/primary MASTER nunca pode ser excluído;
+- MASTER pode excluir qualquer outro usuário;
+- ADMIN pode excluir somente perfis operacionais;
+- ADMIN não pode excluir MASTER nem ADMIN;
+- perfis operacionais não podem excluir usuários.
+
 ## Integração com Empresa
 
 `empresaId` é uma referência lógica externa. Não existe FK cross-service. A existência da empresa é validada pela API interna do PS_Empresa usando `X-Internal-Key`.
 
-## Contrato para PS_Login
+## Contratos internos usados pelo PS_Login
 
-O PS_User expõe um lookup interno mínimo para o futuro PS_Login:
+### Identidade por e-mail
 
 `GET /internal/usuarios/identity?email={email}`
 
 Proteção: `X-Internal-Key`.
 
-Resposta de identidade:
+Resposta mínima:
 
 - `userId`
 - `empresaId`
@@ -70,11 +87,41 @@ Resposta de identidade:
 - `status`
 - `roles`
 
-O endpoint não autentica, não valida senha e não emite JWT. Usuários inativos são retornados com `status=INATIVO`; cabe ao PS_Login impedir a autenticação.
+O PS_Login usa este contrato durante autenticação e recuperação/ativação quando precisa resolver a identidade por e-mail.
 
-## Provisionamento de senha
+### Contexto por usuário
 
-O PS_User não recebe nem armazena senha. Após a criação da identidade, o futuro PS_Login será responsável por enviar um convite de ativação por e-mail para que o próprio usuário defina sua senha. MASTER/ADMIN não define nem visualiza senha de outro usuário.
+`GET /internal/usuarios/{usuarioId}` com `X-Actor-User-Id` do próprio usuário é reutilizado pelo PS_Login para revalidar contexto atual durante refresh e operações sensíveis.
+
+O PS_Login não reaproveita cegamente status/roles de tokens antigos: ele consulta o PS_User antes de renovar sessões ou executar fluxos que exigem identidade ativa.
+
+## Provisionamento de senha e convite
+
+O PS_User **não recebe nem armazena senha**.
+
+Fluxo oficial:
+
+```text
+Orchestrator
+   |
+   | cria identidade
+   v
+PS_User
+   |
+   | user criado
+   v
+Orchestrator
+   |
+   | solicita convite
+   v
+PS_Login
+   |
+   `--> e-mail para o próprio usuário definir a senha
+```
+
+MASTER/ADMIN nunca define nem visualiza a senha de outro usuário.
+
+O PS_User também não deve chamar diretamente o PS_Login dentro da transação de criação do usuário. A coordenação pertence ao componente confiável de onboarding/gestão, evitando acoplamento de domínio e problemas de consistência distribuída entre criação de identidade e envio de convite.
 
 ## Banco
 
@@ -82,4 +129,15 @@ O serviço utiliza banco lógico próprio do PS_User e Flyway para versionamento
 
 ## Estado atual
 
-A reconstrução V1, a hierarquia de usuários e o CRUD administrativo estão implementados. O PS_User permanece separado do PS_Login por responsabilidade de domínio.
+A reconstrução V1, a hierarquia de usuários, o CRUD administrativo e os contratos internos necessários ao PS_Login estão implementados.
+
+O PS_Login já existe como microsserviço separado e é responsável por:
+
+- convite/ativação;
+- login;
+- access JWT;
+- refresh/logout;
+- troca de senha;
+- recuperação/reset de senha.
+
+A próxima integração de produto é conectar a criação de usuário ao convite por meio do Orchestrator/API Gateway, sem mover responsabilidade de credencial para o PS_User.


### PR DESCRIPTION
Atualiza o README do PS_User para refletir:
- PS_Login já implementado e separado;
- regras oficiais MASTER/ADMIN;
- contratos internos usados pelo login/refresh;
- fluxo oficial de convite após criação da identidade;
- decisão de manter a coordenação no Orchestrator, sem chamada direta PS_User -> PS_Login dentro da transação.